### PR TITLE
カテゴリーデータが呼び出されてないバグを解決

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,16 @@
+import 'package:budget/datebases/category_expense_database.dart';
+import 'package:budget/datebases/category_income_database.dart';
 import 'package:budget/notifications/notification_service.dart';
 import 'package:budget/page/home/home_page.dart';
 import 'package:budget/page/input/input_page.dart';
 import 'package:budget/page/list/list_page.dart';
 import 'package:budget/page/setting/setting_page.dart';
 import 'package:budget/provider/shared_preferences_provider.dart';
+import 'package:budget/repositorys/category_expense_repository.dart';
+import 'package:budget/repositorys/category_income_repository.dart';
+import 'package:budget/repositorys/expense_repository.dart';
+import 'package:budget/viewModels/category_expense_model.dart';
+import 'package:budget/viewModels/category_income_model.dart';
 import 'package:budget/widgets/passcode/passcode_lock_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -11,7 +18,6 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:flutter_native_timezone/flutter_native_timezone.dart';
 
 final selectedPageProvider = StateProvider.autoDispose((ref) => 0);
 
@@ -36,6 +42,11 @@ final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  final categoryExoenseModel = CategoryExpenseModel(
+      CategoryExpenseRepository(CategoryExpenseDatabase()));
+  final categoryIncomeModel =
+      CategoryIncomeModel(CategoryIncomeRepository(CategoryIncomeDatabase()));
+
   SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,
   ]);
@@ -45,6 +56,8 @@ void main() async {
     // sharedPreferencesインスタンス生成
     sharedPreferencesProvider
         .overrideWithValue(await SharedPreferences.getInstance()),
+    categoryExpenseModelProvider.overrideWith((ref) => categoryExoenseModel),
+    categoryIncomeModelProvider.overrideWith((ref) => categoryIncomeModel)
   ], child: const MyApp()));
 }
 

--- a/lib/page/income/income_page.dart
+++ b/lib/page/income/income_page.dart
@@ -1,7 +1,7 @@
 import 'package:budget/model/category/category.dart';
 import 'package:budget/model/income/income.dart';
 import 'package:budget/page/expense/expense_page.dart';
-import 'package:budget/viewModels/category_expense_model.dart';
+import 'package:budget/viewModels/category_income_model.dart';
 import 'package:budget/viewModels/income_model.dart';
 import 'package:budget/widgets/category_bottom_sheet_dar.dart';
 import 'package:budget/widgets/dateBar_widget.dart';
@@ -126,8 +126,8 @@ class IncomePage extends ConsumerWidget {
   //カテゴリ欄
   Widget categoryBar(BuildContext context, WidgetRef ref, String itemName) {
     final categoryIndex = ref.watch(categoryIndexProvider);
-    final categorys = ref.watch(categoryExpenseModelProvider);
-    category = categorys.categorys[categoryIndex];
+    final categorys = ref.watch(categoryIncomeModelProvider);
+    category = categorys.categoryIncomes[categoryIndex];
     return Padding(
       padding: const EdgeInsets.only(top: 40),
       child: Column(
@@ -159,7 +159,8 @@ class IncomePage extends ConsumerWidget {
                       style:
                           TextStyle(fontWeight: FontWeight.bold, fontSize: 20)),
                 ),
-                categoryBottomSheetBarButtom(categorys: categorys.categorys),
+                categoryBottomSheetBarButtom(
+                    categorys: categorys.categoryIncomes),
               ])),
         ],
       ),


### PR DESCRIPTION
カテゴリーのデータが呼び出されてないバグを解決
原因：ExpensePageとIncomePageが最初にロードされたときに、CategoryIncomeModelProviderとCategoryExpenseModelProviderが初期化されていないために発生している。

解決方法：ExpensePageとIncomePageが初期化される前にCategoryIncomeModelProviderとCategoryExpenseModelProviderが初期化されるようにする。